### PR TITLE
[28446][FIX] Fix automatic request creation

### DIFF
--- a/maintenance_plan/__manifest__.py
+++ b/maintenance_plan/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Maintenance Plan",
     "summary": "Extends preventive maintenance planning",
-    "version": "15.0.1.10",
+    "version": "15.0.1.11",
     "author": "Camptocamp SA, ForgeFlow, Odoo Community Association (OCA) (Forked by Logicasoft)",
     "license": "AGPL-3",
     "category": "Maintenance",

--- a/maintenance_plan/models/maintenance_equipment.py
+++ b/maintenance_plan/models/maintenance_equipment.py
@@ -119,7 +119,9 @@ class MaintenanceEquipment(models.Model):
         requests = request_model
         # Create maintenance request until we reach planning horizon
         while next_maintenance_date <= horizon_date:
-            if next_maintenance_date >= fields.Date.today():
+            if next_maintenance_date >= fields.Date.today() and not self.maintenance_ids.filtered(
+                lambda m: m.maintenance_plan_id.id == mtn_plan.id and m.request_date == next_maintenance_date
+                          and not m.stage_id.done):
                 vals = self._prepare_request_from_plan(mtn_plan, next_maintenance_date)
                 requests |= request_model.create(vals)
             next_maintenance_date = next_maintenance_date + mtn_plan.get_relativedelta(


### PR DESCRIPTION
The bug came when some maintenance requests were created according to planning horizon, the wrong request was set to done and done date is used as base date. 
Ex. I have 3 requests planned for the 14/9, 14/10 and 14/11. I close the task planned for the 14/11 on the 14/9. The base date to recalculate all the maintenance to create according to the horizon is base maintenance date, so done date. So tasks for the 14/10 and 14/11 are created. 
The proposed solution is to check for duplicates before recreating a maintenance request